### PR TITLE
Reject with error when dispatch can't find transition

### DIFF
--- a/src/__test__/stateMachine.test.ts
+++ b/src/__test__/stateMachine.test.ts
@@ -149,7 +149,9 @@ describe("stateMachine tests", () => {
     const door = new Door(undefined, States.broken);
     expect(door.isBroken()).toBeTruthy();
 
-    await expect(door.open()).rejects.toEqual(undefined);
+    await expect(door.open()).rejects.toThrowError(
+      `No transition: from ${States.broken} event ${Events.open}`
+    );
   });
 
   test("should throw on intermediate state", async () => {
@@ -158,7 +160,9 @@ describe("stateMachine tests", () => {
 
     const prms = /* don't await */ door.close();
     expect(door.isOpen()).toBeTruthy();
-    await expect(door.break()).rejects.toEqual(undefined);
+    await expect(door.break()).rejects.toThrowError(
+      `No transition: from ${States.closing} event ${Events.break}`
+    );
     await prms;
   });
 

--- a/src/stateMachine.ts
+++ b/src/stateMachine.ts
@@ -109,8 +109,9 @@ export class StateMachine<
 
         // no such transition
         if (!found) {
-          this.logger.error(this._formatNoTransitionError(me._current, event));
-          reject();
+          const errorMessage = this._formatNoTransitionError(me._current, event);
+          this.logger.error(errorMessage);
+          reject(new Error(errorMessage));
         }
       }, 0, this);
     });


### PR DESCRIPTION
In the case when dispatch can't find the transition, reject with an error instead of with undefined. This way, users of the library can make use of the error message.

--- 

My apologies if eslint doesn't like these changes. I wasn't able to lint the code because I'm using TypeScript 5.2.2, which is apparently incompatible with the version of eslint (or its plugins?) currently used in this repo. It gives me this error when I run `npm run lint`:

```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.5.0

YOUR TYPESCRIPT VERSION: 5.2.2

Please only submit bug reports when using the officially supported version.

=============

/Users/mike/Projects/gw/typescript-fsm/src/__test__/stateMachine.test.ts
  0:0  error  Parsing error: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead

✖ 1 problem (1 error, 0 warnings)
```