### PR TITLE
chore(readme): fix invalid transition in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ enum Events { open = 100, openComplete, close, closeComplete, break };
 // lets define the transitions that will govern the state-machine
 const transitions = [
   /* fromState        event                 toState         callback */
-  t(States.closed,    Events.opened,        States.opening, onOpen),
+  t(States.closed,    Events.open,        States.opening, onOpen),
   t(States.opening,   Events.openComplete,  States.opened,  justLog),
   t(States.opened,    Events.close,         States.closing, onClose),
   t(States.closing,   Events.closeComplete, States.closed,  justLog),


### PR DESCRIPTION
There's an error in the README example

```bash
No transition: from 1 event 100
Error: No transition: from 1 event 100
    at Timeout._onTimeout (/Users/anhld/Works/code/oss/acoustics/whisper-app/node_modules/typescript-fsm/src/stateMachine.ts:104:18)
    at listOnTimeout (node:internal/timers:566:11)
    at process.processTimers (node:internal/timers:507:7)
```